### PR TITLE
Firmware 0.6.1: add signed gesture-angle readback and NGA2 UDP pose acks

### DIFF
--- a/docs/dual_exo_architecture.md
+++ b/docs/dual_exo_architecture.md
@@ -161,6 +161,20 @@ This works because in Dual mode, all motors (both sides) are in `motor_widgets` 
 In Left Only / Right Only modes, the inactive side is not in `motor_widgets` at all;
 containment relies entirely on the connect-time disable described above.
 
+### Signed gesture-angle reference in dual firmware
+
+Firmware 0.6.1 `get_gesture_sang` / `get_gesture_angles` replies follow a
+first-motor convention. The percentage is the aggregate of every readable
+motor carrying the gesture, including both sides, but the rest-zeroed degree
+scale comes from the first matching motor. In the current dual array that is
+always the left-side instance because IDs 1-9 precede IDs 11-19.
+
+For example, `wrist` aggregates the left/right `wrist` and `wrist2` motors, then
+expresses the result in degrees using left wrist ID 1. The value is not a
+right-side-specific physical angle when the two sides have different
+calibration spans. This convention is deterministic, but downstream analysis
+must account for it or use a side-specific firmware build.
+
 ---
 
 ## Calibration — side-specific apply `[VERIFIED]`

--- a/docs/gotchas.md
+++ b/docs/gotchas.md
@@ -139,6 +139,25 @@ These are different. `SerialComm.receive()` reads until `;`. The sent delimiter 
 
 ---
 
+## `GESTURE_RESULT` can share the next reply frame
+
+`GESTURE_RESULT` is unsolicited telemetry and does not carry the `;` command
+delimiter. `DualSerialComm` retains that line until the next delimited reply,
+so a real frame can contain both an older outcome and the current solicited
+reply, for example:
+
+```text
+GESTURE_RESULT: reached=1 stalled=0 short=0 starved=0
+GESTURE_ANGLES: index=42,-3.75 ...
+```
+
+Reply consumers must forward or record the outcome **and still account for the
+non-outcome line as the current command reply**. Treating the entire frame as
+unsolicited stalls the UDP pending-ack queue and prevents later `NGA2` pose
+acknowledgements from being sent.
+
+---
+
 ## Wrist multi-turn range
 
 Wrist (ID 1): `jointLimits = {-189, 2840}` in `config.h`. Multi-turn mechanism — intentional.
@@ -197,6 +216,35 @@ rather than retuned.
 The same coupling exists around the thumb: `thumbadd` sits on the side of the
 arm and links to the `thumbflex` motor body, which is itself linked to
 `thumbrot`. Treat any of those as single independent axes with care.
+
+---
+
+## Signed gesture degrees use one reference motor (0.6.1)
+
+`get_gesture_sang` and the signed-degree field in `get_gesture_angles` do not
+average raw motor degrees. The firmware first computes the same aggregate
+gesture position used by `get_gesture_angle`, then maps that position onto the
+calibrated span of the **first motor named by the gesture**. Rest is 0 degrees,
+toward flex is positive, and toward extend is negative regardless of encoder
+direction or `flip`.
+
+This is deliberate for multi-motor gestures, whose motors can have different
+calibrated spans:
+
+- `thumb` uses `thumbadd` as its degree reference.
+- `wrist` uses `wrist`, not `wrist2`.
+- A dual build uses the left-side instance of that motor because IDs 1-9 appear
+  before IDs 11-19 in firmware order.
+
+Consequently, a dual-build percentage may reflect both hands while its degree
+scale reflects the left reference motor. Do not interpret the value as a
+side-specific right-hand angle when the two sides have different calibration
+spans. Use a side-specific firmware build or explicitly account for this
+reference convention in downstream analysis.
+
+`nan` in a signed reply means the reference degree scale is unavailable. In a
+combined reply, the percentage/status field may still be valid if other motors
+in the gesture were readable. Code `255,nan` means neither view is available.
 
 ---
 

--- a/docs/serial_protocol.md
+++ b/docs/serial_protocol.md
@@ -52,6 +52,7 @@ disable_ids:11:12:13
 set_exo_mode:gesture_fixed
 get_telemetry_fast:11:12:13:14:15:16:17:18:19
 telemetry_diag:11:12:13:14:15:16:17:18:19
+get_gesture_angles:all
 info
 version
 ```
@@ -77,6 +78,8 @@ read path, including method, elapsed microseconds, and per-motor raw values.
 ```text
 set_gesture_angle:<gesture>:<0-100>
 get_gesture_angle:<gesture|all>
+get_gesture_sang:<gesture|all>
+get_gesture_angles:<gesture|all>
 ```
 
 The percentage interpolates a gesture between its OWN two end postures:
@@ -132,6 +135,57 @@ host must gate on the version (or on whether a probe answers) rather than wait
 for an error reply. Run `check_limits` when a joint reports `255` or refuses to
 move: it prints the resolved `span` per motor and flags `NO_TRAVEL`,
 `HOME_OUTSIDE`, `LIMITS_INVERTED` and `SPAN_REVERSED`.
+
+Firmware **0.6.1** adds two rest-zeroed signed-degree views over the same
+batched position sample:
+
+```text
+get_gesture_sang:<gesture|all>
+GESTURE_SANG: index=-12.50 middle=0.00 ring=8.25 wrist=34.75;
+
+get_gesture_angles:<gesture|all>
+GESTURE_ANGLES: index=0,-12.50 middle=45,0.00 ring=101,8.25 wrist=255,nan;
+```
+
+`get_gesture_sang` (signed angle) returns only the signed physical delta in degrees.
+`get_gesture_angles` returns `<percentage-code>,<signed-degrees>` for each
+gesture, preserving the exact `get_gesture_angle` code in the first field.
+`nan` means the signed angle is unavailable; in the combined reply it can
+coexist with a valid percentage, or with code `255` when no position at all is
+available.
+
+The degree convention is intentionally independent of encoder direction and
+the motor `flip` flag:
+
+- The first motor named by the gesture supplies the calibrated degree scale.
+- Its `rest` target is exactly `0 deg`.
+- Travel from rest toward `flex` is positive.
+- Travel from rest toward `extend` is negative.
+
+If `e`, `r`, and `f` are that reference motor's extend, rest, and flex
+fractions, `t` is the underlying gesture position on the extend-to-flex axis,
+and `S` is the motor's calibrated `getGestureSpan()` in degrees, the returned
+angle is:
+
+```text
+reference_fraction = e + t * (f - e)
+signed_degrees = (reference_fraction - r) * sign(f - r) * abs(S)
+```
+
+The calculation uses the underlying (unclamped) `t`, not status code 101 or
+102, so an out-of-range combined result can legitimately be `101,-15.20` or
+`102,42.10`. All three query forms still cost one Dynamixel batch read.
+
+For multi-motor gestures, the percentage remains the mean of all usable motor
+percentages, while degrees use only the first motor's calibrated span. For
+`thumb` that reference is `thumbadd`; for `wrist` it is `wrist`, not `wrist2`.
+In a dual build the first matching motor is on the left side because IDs 1-9
+precede IDs 11-19. The percentage can therefore aggregate both sides while the
+degree scale comes from the left reference motor. Use side-specific firmware
+or account for that convention when left and right calibration spans differ.
+
+Firmware older than **0.6.1** ignores both new command names silently. Gate
+host calls on the version or probe for a correctly prefixed reply.
 
 ### Direct velocity/current control
 
@@ -205,7 +259,9 @@ breaks the corresponding Python code.
 |------------------------|-----------|----------|
 | `name: <word>` | `calibrate_exo.py`, `rom_assessment.py` | Motor name discovery via `info` command |
 | `absolute_angle:<value>` | `calibrate_exo.py`, `rom_assessment.py` | Angle reads |
-| `GESTURE_ANGLE: <name>=<code> ...` | `_hand_exo.py:parse_gesture_angles`, `udp_gesture_receiver.py` | Joint positions / pose acks |
+| `GESTURE_ANGLE: <name>=<code> ...` | `_hand_exo.py:parse_gesture_angles` | Legacy percentage/status read-back |
+| `GESTURE_SANG: <name>=<degrees> ...` | `_hand_exo.py:parse_gesture_signed_angles` | Rest-zeroed signed joint angles |
+| `GESTURE_ANGLES: <name>=<code>,<degrees> ...` | `_hand_exo.py:parse_gesture_angle_pairs`, `udp_gesture_receiver.py` | Combined joint positions / NGA2 pose acks |
 | `GESTURE_RESULT: reached=N ...` | `udp_gesture_receiver.py`, `udp_gesture_gui.py` | Asynchronous move verdicts |
 
 Regex used: `re.search(r"name:\s*(\w+)", line)` and `line.split("absolute_angle:")`.

--- a/examples/08_udp/udp_gesture_gui.py
+++ b/examples/08_udp/udp_gesture_gui.py
@@ -19,9 +19,9 @@ Protocol (see Receiver in udp_gesture_receiver.py):
   * Command integers are then acked by echoing them back, but only once the
     DEVICE has actually replied -- an ack here means the exo executed it, not
     merely that the datagram arrived.
-  * A packed binary pose frame follows each ack, carrying where all seven
-    joints now sit as percentages of their calibrated travel. A joint whose
-    percentage never changes -- or that reports no position at all -- is one
+  * A packed binary pose frame follows each ack, carrying both the percentage
+    code and the rest-zeroed signed degree angle for all six joints. A joint
+    whose values never change -- or that reports no position at all -- is one
     the firmware accepted a command for and could not actually move.
   * The negated port arriving means the receiver is shutting down.
 
@@ -436,22 +436,41 @@ class UdpGestureGui:
         """Render the packed pose frame that follows a command ack.
 
         This is the panel's answer to "did anything move?": a joint whose
-        percentage does not change between commands, or that reports 255, is
-        one the exo accepted a goal for and could not travel.
+        percentage/degree pair does not change between commands, or whose
+        fraction reports 255, is one the exo accepted a goal for and could not
+        travel.
         """
         parsed = unpack_pose_ack(data)
         if parsed is None:
             self.log(f"<- unparseable pose frame ({len(data)} bytes)")
             return
-        _, pose = parsed
-        stuck = [joint for joint, code in pose.items() if code == POSE_UNAVAILABLE]
-        rendered = " ".join(
-            f"{joint}={'--' if pose[joint] == POSE_UNAVAILABLE else pose[joint]}"
-            for joint in JOINTS
-        )
-        self.log(f"   pose: {rendered}")
+        ack_value, pose = parsed
+        stuck = [
+            joint for joint, record in pose.items()
+            if record["fraction"] == POSE_UNAVAILABLE
+        ]
+        rendered_parts = []
+        for joint in JOINTS:
+            record = pose[joint]
+            fraction = record["fraction"]
+            angle = record["angle_delta_deg"]
+            if fraction == POSE_UNAVAILABLE:
+                fraction_text = "--"
+            elif fraction == 101:
+                fraction_text = "below"
+            elif fraction == 102:
+                fraction_text = "above"
+            else:
+                fraction_text = f"{fraction}%"
+            angle_text = "--" if angle is None else f"{angle:+.2f}deg"
+            rendered_parts.append(f"{joint}={fraction_text}/{angle_text}")
+        rendered = " ".join(rendered_parts)
+        self.log(f"<- pose ack {ack_value:+d}: {rendered}")
         if stuck:
-            self.log(f"   !! no calibrated travel: {', '.join(stuck)}")
+            self.log(
+                f"   !! position unavailable (no travel or read failure): "
+                f"{', '.join(stuck)}"
+            )
 
     def _handle_outcome(self, payload):
         """Render a GESTURE_RESULT line and flag anything that did not move."""

--- a/examples/08_udp/udp_gesture_receiver.py
+++ b/examples/08_udp/udp_gesture_receiver.py
@@ -14,17 +14,19 @@ thread, so they never gate the command path.
 
 Edit build_command_map() below to change the integer -> command associations.
 
-Each acked command is followed by a packed binary frame carrying where all
-seven joints now sit, as percentages of their calibrated travel -- so a
-consumer learns the resulting pose without polling for it. The ASCII integer
-ack is unchanged and still goes out first; the pose is an additional datagram
-that only readers who know its magic need to look at. See pack_pose_ack().
+Each acked command is followed by a packed binary frame carrying both the
+gesture percentage/status code and the rest-zeroed signed angle for all six
+joints, so a consumer learns the resulting pose without polling for it. The
+ASCII integer ack is unchanged and still goes out first; the pose is an
+additional datagram that only readers who know its magic need to look at. See
+pack_pose_ack().
 
-Requires firmware >= 0.6.0: per-joint moves use set_gesture_angle, whose
+Requires firmware >= 0.6.1: per-joint moves use set_gesture_angle, whose
 percentages interpolate each gesture's extend and flex postures from that
-version on, and `wrist` drives both dorsal wrist motors together. Pose acks
-switch themselves off against anything older. Use examples/08_udp/udp_gesture_gui.py
-to drive this receiver by hand.
+version on, and `wrist` drives both dorsal wrist motors together. The pose ack
+uses get_gesture_angles, added in 0.6.1, and switches itself off against
+anything older. Use examples/08_udp/udp_gesture_gui.py to drive this receiver
+by hand.
 
 Usage:
     python examples/08_udp/udp_gesture_receiver.py
@@ -51,8 +53,8 @@ import time
 
 from nml_hand_exo import DualSerialComm
 from nml_hand_exo.interface._hand_exo import (
-    GESTURE_ANGLE_PREFIX,
-    parse_gesture_angles,
+    GESTURE_ANGLES_PREFIX,
+    parse_gesture_angle_pairs,
 )
 from nml_hand_exo.interface._udp_command_bindings import (
     UDP_CONNECTION_PORT_MAX,
@@ -157,25 +159,28 @@ GESTURE_RESULT_PREFIX = "GESTURE_RESULT:"
 # ---- Pose acks --------------------------------------------------------------
 # Every dispatched command is followed by this query, so the ack can carry where
 # the hand actually IS rather than only which integer was accepted. One batched
-# Dynamixel read on the device side (firmware >= 0.6.0), issued after the move
+# Dynamixel read on the device side (firmware >= 0.6.1), issued after the move
 # command so it never delays it.
-POSE_QUERY = "get_gesture_angle:all"
+POSE_QUERY = "get_gesture_angles:all"
 
 # The pose travels as its own datagram in a packed binary frame:
 #
-#     magic[4] | int16 value | uint8 count | uint8 code * count
+#     little-endian: magic[4] | int16 value | uint8 count |
+#         (uint8 fraction-code | float32 angle-delta-deg) * count
 #
-# struct rather than text on both ends: the values are already integers in the
-# firmware, and a fixed-width frame costs one memcpy per hop instead of a
-# format-then-reparse. It is a SECOND datagram rather than a new encoding for
-# the ack itself, so every existing consumer of the ASCII integer protocol keeps
-# working untouched and only readers that know the magic pay attention.
+# The NGA2 magic versions the widened record; NGA1 carried only the uint8
+# percentage code. It remains a SECOND datagram rather than a new encoding for
+# the ack itself, so every existing consumer of the ASCII integer protocol
+# keeps working untouched and only readers that know the magic pay attention.
 #
 # `value` is the same integer the ASCII ack carries, so a consumer that reads
-# only these frames still knows which command each pose belongs to. Codes are
-# the firmware's: 0-100 percent, 101/102 out of range low/high, 255 unavailable.
-POSE_ACK_MAGIC = b"NGA1"
+# only these frames still knows which command each pose belongs to. Fraction
+# codes are the firmware's: 0-100 percent, 101/102 out of range low/high, 255
+# unavailable. The float is a signed physical delta from rest: flex positive,
+# extend negative. IEEE NAN means that signed angle is unavailable.
+POSE_ACK_MAGIC = b"NGA2"
 POSE_ACK_HEADER = "<4shB"
+POSE_ACK_RECORD = "Bf"
 
 #: Firmware code for "no position available for this joint" -- it has no
 #: calibrated travel, or the position read failed. Also used locally for a
@@ -189,15 +194,21 @@ def pack_pose_ack(value, joints, pose):
     Args:
         value (int): The command integer being acked.
         joints (tuple[str, ...]): Joint order for the payload.
-        pose (dict): Gesture name -> code, as parsed from the device.
+        pose (dict): Gesture name -> combined ``fraction`` and
+            ``angle_delta_deg`` fields, as parsed from the device.
 
     Returns:
-        bytes: Packed frame, joints missing from ``pose`` reported as 255.
+        bytes: Packed frame. Missing joints use fraction code 255 and NAN.
     """
-    codes = [int(pose.get(joint, POSE_UNAVAILABLE)) & 0xFF for joint in joints]
+    values = []
+    for joint in joints:
+        record = pose.get(joint) or {}
+        fraction = int(record.get("fraction", POSE_UNAVAILABLE)) & 0xFF
+        angle = record.get("angle_delta_deg")
+        values.extend((fraction, float("nan") if angle is None else float(angle)))
     return struct.pack(
-        POSE_ACK_HEADER + "B" * len(codes), POSE_ACK_MAGIC, int(value), len(codes),
-        *codes,
+        POSE_ACK_HEADER + POSE_ACK_RECORD * len(joints),
+        POSE_ACK_MAGIC, int(value), len(joints), *values,
     )
 
 
@@ -214,10 +225,19 @@ def unpack_pose_ack(data):
     if not data or len(data) < header_len or not data.startswith(POSE_ACK_MAGIC):
         return None
     _, value, count = struct.unpack_from(POSE_ACK_HEADER, data)
-    if len(data) < header_len + count or count != len(JOINTS):
+    record_len = struct.calcsize("<" + POSE_ACK_RECORD)
+    if len(data) < header_len + count * record_len or count != len(JOINTS):
         return None
-    codes = struct.unpack_from("B" * count, data, header_len)
-    return value, dict(zip(JOINTS, codes))
+    pose = {}
+    offset = header_len
+    for joint in JOINTS:
+        fraction, angle = struct.unpack_from("<" + POSE_ACK_RECORD, data, offset)
+        pose[joint] = {
+            "fraction": fraction,
+            "angle_delta_deg": angle if angle == angle else None,
+        }
+        offset += record_len
+    return value, pose
 
 
 def parse_passthrough_command(payload):
@@ -450,13 +470,15 @@ class MockComm:
             return "Hold current: 25 mA"
         if head == "set_current_governor":
             return f"OK: current_governor {rest}"
-        if head == "get_gesture_angle":
+        if head == "get_gesture_angles":
             # Fixed pose: the mock has no motors, so there is nothing to move
             # and nothing to read. The point is that the query ANSWERS, which
             # is what the ack correlation and the pose frame depend on.
             codes = (0, 25, 50, 75, 100, 101, 102, 255)
-            return GESTURE_ANGLE_PREFIX + " " + " ".join(
-                f"{joint}={code}" for joint, code in zip(JOINTS, codes)
+            angles = (-12.5, -4.0, 0.0, 8.25, 16.5, 24.0)
+            return GESTURE_ANGLES_PREFIX + " " + " ".join(
+                f"{joint}={code},{angle:.2f}"
+                for joint, code, angle in zip(JOINTS, codes, angles)
             )
         if head == "home":
             return f"OK: home {rest}"
@@ -585,7 +607,7 @@ class Receiver:
             reply = self.comm.receive(wait_until_return=True, timeout=timeout)
             if not reply:
                 break
-            pose = parse_gesture_angles(reply)
+            pose = parse_gesture_angle_pairs(reply)
             if pose:
                 self.pose = pose
                 print(f"  pose acks enabled: {self._format_pose(pose)}")
@@ -593,13 +615,19 @@ class Receiver:
         self.pose_ack = False
         print("  [warn] device did not answer "
               f"{POSE_QUERY!r}; pose acks disabled "
-              "(needs firmware >= 0.6.0)", file=sys.stderr)
+              "(needs firmware >= 0.6.1)", file=sys.stderr)
         return False
 
     @staticmethod
     def _format_pose(pose):
-        return " ".join(f"{joint}={pose.get(joint, POSE_UNAVAILABLE)}"
-                        for joint in JOINTS)
+        rendered = []
+        for joint in JOINTS:
+            record = pose.get(joint) or {}
+            fraction = record.get("fraction", POSE_UNAVAILABLE)
+            angle = record.get("angle_delta_deg")
+            angle_text = "nan" if angle is None else f"{angle:+.2f}deg"
+            rendered.append(f"{joint}={fraction}%/{angle_text}")
+        return " ".join(rendered)
 
     # -- upstream (UDP) ------------------------------------------------
 
@@ -753,29 +781,37 @@ class Receiver:
             reply = self.comm.receive()          # non-blocking
             if not reply:
                 return
+            reply_lines = [line.strip() for line in reply.splitlines()
+                           if line.strip()]
             outcome_lines = []
-            for line in reply.splitlines():
+            solicited_lines = []
+            for line in reply_lines:
                 if self.echo_replies:
                     print(f"      <- {line}")
-                if line.strip().startswith(GESTURE_RESULT_PREFIX):
-                    outcome_lines.append(line.strip())
+                if line.startswith(GESTURE_RESULT_PREFIX):
+                    outcome_lines.append(line)
+                else:
+                    solicited_lines.append(line)
 
             # A pose reply is SOLICITED -- it answers the query appended to the
             # batch -- so it is recorded and then falls through to retire its
-            # slot like any other reply. Only the unsolicited outcome report
-            # below skips retirement.
-            if GESTURE_ANGLE_PREFIX in reply:
-                pose = parse_gesture_angles(reply)
+            # slot like any other reply. A standalone unsolicited outcome skips
+            # retirement; an outcome coalesced with this reply does not hide it.
+            if GESTURE_ANGLES_PREFIX in reply:
+                pose = parse_gesture_angle_pairs(reply)
                 if pose:
                     self.pose = pose
 
-            if outcome_lines:
-                # Unsolicited: it answers no outstanding command, so retiring a
-                # pending ack against it would ack the WRONG command -- and the
-                # next real reply would then have nothing left to retire.
-                for line in outcome_lines:
-                    self.outcomes += 1
-                    self.send_text_upstream(line)
+            # GESTURE_RESULT has no command delimiter. DualSerialComm therefore
+            # retains it as pending telemetry until the NEXT delimited command
+            # reply arrives, and publishes both lines in one frame. Forward the
+            # outcome, but do not discard the solicited reply sharing its frame.
+            # A standalone outcome (the mock transport and simple test stubs can
+            # produce one) still must not retire a pending command.
+            for line in outcome_lines:
+                self.outcomes += 1
+                self.send_text_upstream(line)
+            if not solicited_lines:
                 continue
             self._retire_pending()
 
@@ -803,7 +839,7 @@ class Receiver:
         print(f"  commands dispatched: {self.dispatched}")
         print(f"  acks sent upstream : {self.acked}")
         print(f"  pose frames sent   : {self.pose_acks}"
-              + ("" if self.pose_ack else "  (disabled: firmware < 0.6.0)"))
+              + ("" if self.pose_ack else "  (disabled: firmware < 0.6.1)"))
         print(f"  move outcomes      : {self.outcomes}")
         print(f"  unmapped values    : {self.unmapped}")
         print(f"  malformed payloads : {self.malformed}")
@@ -863,9 +899,10 @@ def main(argv=None):
     parser.add_argument("--no-pose-ack", dest="pose_ack", action="store_false",
                         help="Do not query the joint positions after each "
                              "command. By default every ack is followed by a "
-                             "packed frame carrying all 7 joint percentages, "
+                             "packed frame carrying each joint's percentage "
+                             "code and rest-zeroed signed degree angle, "
                              "which costs one extra device round trip per "
-                             "command and needs firmware >= 0.6.0.")
+                             "command and needs firmware >= 0.6.1.")
     parser.add_argument("--quiet", action="store_true",
                         help="Do not log each datagram.")
     parser.add_argument("--mock", action="store_true",

--- a/examples/README.md
+++ b/examples/README.md
@@ -290,6 +290,10 @@ python examples/06_lsl_streaming/LSL/lsl_rms_barplot.py --type EMG --name OpenEp
 
 The two scripts in `08_udp` are designed to run together. `udp_gesture_receiver.py` owns the dual-CDC connection to the exo, translates UDP integers into gesture commands, and returns acknowledgements. `udp_gesture_gui.py` is the manual UDP control panel used to register the acknowledgement port and send those integers.
 
+Firmware **0.6.1 or newer** is required for pose acknowledgements. After each unchanged ASCII integer ack, the receiver sends an additive `NGA2` binary datagram containing a percentage/status code and a rest-zeroed signed degree angle for each of the six joints. The degree convention matches `get_gesture_angles`: rest is 0 degrees, toward flex is positive, and toward extend is negative. The receiver probes `get_gesture_angles:all` at startup and automatically disables pose frames if the firmware does not answer, so command acknowledgements continue to flow.
+
+Little-endian `NGA2` records are `(uint8 fraction_code, float32 angle_delta_deg)`. Fraction codes 0-100 are positions, 101/102 are below/above the gesture endpoints, and 255 is unavailable; an unavailable signed angle is IEEE `NaN`. The frame magic was bumped from `NGA1` because `NGA1` carried percentage codes only. Use `pack_pose_ack()` and `unpack_pose_ack()` from `udp_gesture_receiver.py` rather than decoding the frame layout independently.
+
 > **Safety:** The receiver arms and homes the exo by default. Keep hands and obstructions clear before starting it.
 
 1. Start the receiver in the first terminal. Its defaults use `COM10` for commands and `COM11` for telemetry; pass the appropriate ports if your system enumerated them differently.
@@ -403,6 +407,10 @@ exo.cycle_gesture()
 
 # Cycle through gesture states
 exo.cycle_gesture_state()
+
+# Firmware >= 0.6.1: read percentage/status and rest-zeroed signed degrees
+pose = exo.get_gesture_angles("index")
+# {"index": {"fraction": 42, "angle_delta_deg": -3.75}}
 ```
 
 ---

--- a/examples/tests/test_firmware_feature_gates.py
+++ b/examples/tests/test_firmware_feature_gates.py
@@ -4,12 +4,15 @@ from nml_hand_exo.interface._hand_exo import (
     ANGLE_ADDRESSABLE_GESTURES,
     FW_CURRENT_BUDGET,
     FW_GESTURE_ANGLE_READBACK,
+    FW_GESTURE_SIGNED_ANGLE,
     FW_PER_JOINT_REST,
     FW_RAD_GESTURE,
     GESTURE_ANGLE_ABOVE_RANGE,
     GESTURE_ANGLE_BELOW_RANGE,
     GESTURE_ANGLE_PREFIX,
+    GESTURE_ANGLES_PREFIX,
     GESTURE_ANGLE_UNAVAILABLE,
+    GESTURE_SANG_PREFIX,
     GESTURE_MAX_FIRMWARE,
     GESTURE_MIN_FIRMWARE,
     HandExo,
@@ -325,6 +328,49 @@ class GestureAngleReadbackTests(unittest.TestCase):
         exo = _exo("0.6.0")
         exo.device.next_reply = ""
         self.assertEqual(exo.get_gesture_angle(), {})
+
+
+class GestureSignedAngleReadbackTests(unittest.TestCase):
+    """Rest-zeroed signed and combined read-back landed in firmware 0.6.1."""
+
+    def test_signed_queries_are_gated_off_on_0_6_0(self):
+        exo = _exo("0.6.0")
+        with self.assertRaises(RuntimeError):
+            exo.get_gesture_sang()
+        with self.assertRaises(RuntimeError):
+            exo.get_gesture_angles()
+        self.assertEqual(exo.device.sent, [])
+
+    def test_signed_angle_readback_uses_float_degrees_and_none_for_nan(self):
+        exo = _exo("0.6.1")
+        exo.device.next_reply = (
+            GESTURE_SANG_PREFIX + " index=-12.50 middle=0.00 wrist=34.75 thumb=nan;"
+        )
+        angles = exo.get_gesture_sang()
+        self.assertEqual(exo.device.sent[-1], "get_gesture_sang:all\n")
+        self.assertEqual(angles["index"], -12.5)
+        self.assertEqual(angles["middle"], 0.0)
+        self.assertEqual(angles["wrist"], 34.75)
+        self.assertIsNone(angles["thumb"])
+
+    def test_combined_readback_preserves_fraction_codes_and_signed_degrees(self):
+        exo = _exo("0.6.1")
+        exo.device.next_reply = (
+            GESTURE_ANGLES_PREFIX
+            + " index=0,-12.50 middle=45,0.00 ring=101,8.25 wrist=255,nan;"
+        )
+        angles = exo.get_gesture_angles("Index")
+        self.assertEqual(exo.device.sent[-1], "get_gesture_angles:index\n")
+        self.assertEqual(
+            angles["index"], {"fraction": 0, "angle_delta_deg": -12.5}
+        )
+        self.assertEqual(angles["ring"]["fraction"], GESTURE_ANGLE_BELOW_RANGE)
+        self.assertEqual(angles["ring"]["angle_delta_deg"], 8.25)
+        self.assertEqual(angles["wrist"]["fraction"], GESTURE_ANGLE_UNAVAILABLE)
+        self.assertIsNone(angles["wrist"]["angle_delta_deg"])
+
+    def test_signed_angle_feature_follows_percentage_readback(self):
+        self.assertGreater(FW_GESTURE_SIGNED_ANGLE, FW_GESTURE_ANGLE_READBACK)
 
 
 if __name__ == "__main__":

--- a/examples/tests/test_udp_passthrough.py
+++ b/examples/tests/test_udp_passthrough.py
@@ -3,7 +3,7 @@ import sys
 import unittest
 
 sys.path.insert(
-    0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts")
+    0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "08_udp")
 )
 
 from udp_gesture_receiver import (  # noqa: E402
@@ -21,8 +21,8 @@ from udp_gesture_receiver import (  # noqa: E402
     unpack_pose_ack,
 )
 from nml_hand_exo.interface._hand_exo import (  # noqa: E402
-    GESTURE_ANGLE_PREFIX,
-    parse_gesture_angles,
+    GESTURE_ANGLES_PREFIX,
+    parse_gesture_angle_pairs,
 )
 from nml_hand_exo.interface._udp_command_bindings import (  # noqa: E402
     UDP_CONNECTION_PORT_THRESHOLD,
@@ -140,6 +140,31 @@ class MoveOutcomeTests(unittest.TestCase):
         self.assertEqual(receiver.outcomes, 1)
         self.assertEqual(len(receiver._pending), 0)
 
+    def test_coalesced_outcome_does_not_hide_the_delimited_command_reply(self):
+        """Real dual-CDC framing can prepend a stale outcome to the next reply."""
+        sent_upstream = []
+
+        class _Comm:
+            replies = [
+                "GESTURE_RESULT: reached=1 stalled=0 short=0 starved=0\n"
+                "OK: gesture index:flex"
+            ]
+
+            def receive(self, *a, **k):
+                return self.replies.pop(0) if self.replies else ""
+
+        receiver = Receiver(_Comm(), COMMAND_MAP, echo_replies=False, verbose=False)
+        receiver.return_addr = ("127.0.0.1", 10004)
+        receiver.send_upstream = lambda v: (sent_upstream.append(int(v)), True)[1]
+        receiver.send_text_upstream = lambda t: True
+        receiver._pending.append([2, 1])
+
+        receiver.drain_replies()
+
+        self.assertEqual(sent_upstream, [2])
+        self.assertEqual(receiver.outcomes, 1)
+        self.assertEqual(len(receiver._pending), 0)
+
 class _PoseComm:
     """Comm stub that replays a fixed list of reply frames, then nothing."""
 
@@ -164,45 +189,61 @@ def _receiver(replies, **kwargs):
     return receiver
 
 
-class GestureAngleParsingTests(unittest.TestCase):
+class GestureAnglePairParsingTests(unittest.TestCase):
     """The device line the pose ack is built from."""
 
-    LINE = (GESTURE_ANGLE_PREFIX + " thumb=12 index=0 middle=45 ring=101 "
-            "pinky=100 wrist=33;")
+    LINE = (GESTURE_ANGLES_PREFIX + " thumb=12,-5.50 index=0,-12.00 "
+            "middle=45,0.00 ring=101,8.25 pinky=100,16.50 wrist=33,nan;")
 
     def test_parses_every_joint_including_the_status_codes(self):
         self.assertEqual(
-            parse_gesture_angles(self.LINE),
-            {"thumb": 12, "index": 0, "middle": 45, "ring": 101,
-             "pinky": 100, "wrist": 33},
+            parse_gesture_angle_pairs(self.LINE),
+            {
+                "thumb": {"fraction": 12, "angle_delta_deg": -5.5},
+                "index": {"fraction": 0, "angle_delta_deg": -12.0},
+                "middle": {"fraction": 45, "angle_delta_deg": 0.0},
+                "ring": {"fraction": 101, "angle_delta_deg": 8.25},
+                "pinky": {"fraction": 100, "angle_delta_deg": 16.5},
+                "wrist": {"fraction": 33, "angle_delta_deg": None},
+            },
         )
 
     def test_covers_exactly_the_joints_the_receiver_reports(self):
-        self.assertEqual(set(parse_gesture_angles(self.LINE)), set(JOINTS))
+        self.assertEqual(set(parse_gesture_angle_pairs(self.LINE)), set(JOINTS))
 
     def test_finds_the_line_inside_surrounding_device_chatter(self):
         noisy = "\n".join(["[GestureController] targets: 11->204.96",
                            self.LINE, "GESTURE_RESULT: reached=1"])
-        self.assertEqual(parse_gesture_angles(noisy)["wrist"], 33)
+        self.assertEqual(
+            parse_gesture_angle_pairs(noisy)["wrist"]["fraction"], 33
+        )
 
     def test_unrelated_or_truncated_input_yields_no_pose_rather_than_raising(self):
         # A poller on the hot path must not take an exception from a dropped
         # USB frame; a missing key is the easier failure to handle.
         for text in ("", None, "OK: gesture_angle index:35.0;",
-                     GESTURE_ANGLE_PREFIX + " thumb= index=7 =3 middle"):
-            parsed = parse_gesture_angles(text)
+                     GESTURE_ANGLES_PREFIX + " thumb= index=7 =3 middle"):
+            parsed = parse_gesture_angle_pairs(text)
             self.assertIsInstance(parsed, dict)
         self.assertEqual(
-            parse_gesture_angles(GESTURE_ANGLE_PREFIX + " thumb= index=7 =3"),
-            {"index": 7},
+            parse_gesture_angle_pairs(
+                GESTURE_ANGLES_PREFIX + " thumb= index=7,-3.5 =3"
+            ),
+            {"index": {"fraction": 7, "angle_delta_deg": -3.5}},
         )
 
 
 class PoseAckFrameTests(unittest.TestCase):
     """The packed frame that carries the pose upstream."""
 
-    POSE = {"thumb": 0, "index": 25, "middle": 50, "ring": 75,
-            "pinky": 100, "wrist": 101}
+    POSE = {
+        "thumb": {"fraction": 0, "angle_delta_deg": -10.0},
+        "index": {"fraction": 25, "angle_delta_deg": -2.5},
+        "middle": {"fraction": 50, "angle_delta_deg": 0.0},
+        "ring": {"fraction": 75, "angle_delta_deg": 5.0},
+        "pinky": {"fraction": 100, "angle_delta_deg": 10.0},
+        "wrist": {"fraction": 101, "angle_delta_deg": None},
+    }
 
     def test_round_trips_value_and_every_joint(self):
         frame = pack_pose_ack(-3, JOINTS, self.POSE)
@@ -213,15 +254,19 @@ class PoseAckFrameTests(unittest.TestCase):
     def test_frame_is_fixed_width_and_magic_prefixed(self):
         frame = pack_pose_ack(2, JOINTS, self.POSE)
         self.assertTrue(frame.startswith(POSE_ACK_MAGIC))
-        # magic(4) + int16 value + uint8 count + one byte per joint
-        self.assertEqual(len(frame), 4 + 2 + 1 + len(JOINTS))
+        # magic(4) + int16 value + uint8 count + (uint8 + float32) per joint
+        self.assertEqual(len(frame), 4 + 2 + 1 + 5 * len(JOINTS))
 
     def test_missing_joints_report_unavailable_not_zero(self):
         # 0 is a real position (home); a joint the device never mentioned is
         # not at home, it is unknown, and the two must not be conflated.
-        _, pose = unpack_pose_ack(pack_pose_ack(1, JOINTS, {"index": 40}))
-        self.assertEqual(pose["index"], 40)
-        self.assertEqual(pose["thumb"], POSE_UNAVAILABLE)
+        _, pose = unpack_pose_ack(pack_pose_ack(1, JOINTS, {
+            "index": {"fraction": 40, "angle_delta_deg": 1.25}
+        }))
+        self.assertEqual(pose["index"]["fraction"], 40)
+        self.assertAlmostEqual(pose["index"]["angle_delta_deg"], 1.25)
+        self.assertEqual(pose["thumb"]["fraction"], POSE_UNAVAILABLE)
+        self.assertIsNone(pose["thumb"]["angle_delta_deg"])
 
     def test_rejects_text_and_truncated_frames(self):
         for bad in (b"", b"2", b"GESTURE_RESULT: reached=1",
@@ -236,8 +281,8 @@ class PoseAckFrameTests(unittest.TestCase):
 class PoseAckFlowTests(unittest.TestCase):
     """Pose queries ride along with commands without disturbing the acks."""
 
-    POSE_LINE = (GESTURE_ANGLE_PREFIX + " thumb=1 index=2 middle=3 ring=4 "
-                 "pinky=5 wrist=6")
+    POSE_LINE = (GESTURE_ANGLES_PREFIX + " thumb=1,-5.0 index=2,-4.0 "
+                 "middle=3,-3.0 ring=4,-2.0 pinky=5,-1.0 wrist=6,0.0")
 
     def test_query_is_appended_after_the_command_not_before_it(self):
         # Ordering matters: the query must never delay the move it reports on.
@@ -269,7 +314,9 @@ class PoseAckFlowTests(unittest.TestCase):
         self.assertEqual(len(receiver._pending), 0, "both replies accounted for")
         self.assertEqual([kind for kind, _ in sent], ["int", "pose"])
         self.assertEqual(sent[0][1], 2)
-        self.assertEqual(unpack_pose_ack(sent[1][1])[1]["wrist"], 6)
+        wrist = unpack_pose_ack(sent[1][1])[1]["wrist"]
+        self.assertEqual(wrist["fraction"], 6)
+        self.assertAlmostEqual(wrist["angle_delta_deg"], 0.0)
 
     def test_pose_reply_retires_its_own_slot_unlike_a_move_outcome(self):
         # The pose answers a query we sent, so it is solicited and must retire
@@ -286,13 +333,33 @@ class PoseAckFlowTests(unittest.TestCase):
         self.assertEqual(acked, [2])
         self.assertEqual(receiver.outcomes, 1)
 
+    def test_pose_ack_survives_outcome_coalesced_into_its_serial_frame(self):
+        receiver = _receiver([
+            "OK: gesture_angle index:85.0",
+            "GESTURE_RESULT: reached=1 stalled=0\n" + self.POSE_LINE,
+        ])
+        sent = []
+        receiver.send_upstream = lambda v: (sent.append(("int", int(v))), True)[1]
+        receiver.send_text_upstream = lambda t: (sent.append(("outcome", t)), True)[1]
+        receiver.send_pose_upstream = lambda v: (
+            sent.append(("pose", pack_pose_ack(v, JOINTS, receiver.pose))), True
+        )[1]
+
+        receiver.handle("2", "127.0.0.1:1")
+        receiver.drain_replies()
+
+        self.assertEqual([kind for kind, _ in sent], ["outcome", "int", "pose"])
+        self.assertEqual(len(receiver._pending), 0)
+        pose = unpack_pose_ack(sent[-1][1])[1]
+        self.assertEqual(pose["wrist"]["fraction"], 6)
+
     def test_silent_firmware_disables_pose_acks_instead_of_stalling_them(self):
         # An unknown command is SILENT in firmware. Left enabled, every command
         # would wait forever on a reply that never comes.
         class _Older(MockComm):
             @staticmethod
             def _reply_for(command):
-                if command.startswith("get_gesture_angle"):
+                if command.startswith("get_gesture_angles"):
                     return None
                 return MockComm._reply_for(command)
 

--- a/examples/udp_bindings/Digits_and_Wrist_Posture.json
+++ b/examples/udp_bindings/Digits_and_Wrist_Posture.json
@@ -1,0 +1,108 @@
+{
+  "schema_version": 3,
+  "name": "Digits and Wrist (Posture)",
+  "control_mode": "position",
+  "target": "Right Only",
+  "repeat_ms": 100,
+  "pulse_shape": "raised_cosine",
+  "pulse_duration_ms": 1000,
+  "pulse_step_ms": 20,
+  "ease_duration_ms": 800,
+  "bindings": [
+    {
+      "value": -6,
+      "command": "set_gesture:wrist:extend",
+      "description": "Wrist Extension"
+    },
+    {
+      "value": -5,
+      "command": "set_gesture:pinky:extend",
+      "description": "Pinky extension"
+    },
+    {
+      "value": -4,
+      "command": "set_gesture:ring:extend",
+      "description": "Ring extension"
+    },
+    {
+      "value": -3,
+      "command": "set_gesture:middle:extend",
+      "description": "Middle extension"
+    },
+    {
+      "value": -2,
+      "command": "set_gesture:index:extend",
+      "description": "Index extension"
+    },
+    {
+      "value": -1,
+      "command": "set_gesture:thumb:extend",
+      "description": "Thumb extension"
+    },
+    {
+      "value": 0,
+      "command": "set_gesture:grasp:open",
+      "description": "REST / no torque"
+    },
+    {
+      "value": 1,
+      "command": "set_gesture:thumb:flex",
+      "description": "Thumb flexion"
+    },
+    {
+      "value": 2,
+      "command": "set_gesture:index:flex",
+      "description": "Index flexion"
+    },
+    {
+      "value": 3,
+      "command": "set_gesture:middle:flex",
+      "description": "Middle flexion"
+    },
+    {
+      "value": 4,
+      "command": "set_gesture:ring:flex",
+      "description": "Ring flexion"
+    },
+    {
+      "value": 5,
+      "command": "set_gesture:pinky:flex",
+      "description": "Pinky flexion"
+    },
+    {
+      "value": 6,
+      "command": "set_gesture:wrist:flex",
+      "description": "Wrist Flexion"
+    },
+    {
+      "value": 11,
+      "command": "set_gesture:thumb:rest",
+      "description": "Thumb Neutral"
+    },
+    {
+      "value": 12,
+      "command": "set_gesture:index:rest",
+      "description": "Index Neutral"
+    },
+    {
+      "value": 13,
+      "command": "set_gesture:middle:rest",
+      "description": "Middle Neutral"
+    },
+    {
+      "value": 14,
+      "command": "set_gesture:ring:rest",
+      "description": "Ring Neutral"
+    },
+    {
+      "value": 15,
+      "command": "set_gesture:pinky:rest",
+      "description": "Pinky Neutral"
+    },
+    {
+      "value": 16,
+      "command": "set_gesture:wrist:rest",
+      "description": "Wrist Neutral"
+    }
+  ]
+}

--- a/src/cpp/nml_hand_exo/config.h
+++ b/src/cpp/nml_hand_exo/config.h
@@ -469,8 +469,10 @@ constexpr int N_GESTURES = 15;
 // and `get_gesture_angle` inverts it. Retuning EXTEND_*/FLEX_* therefore moves
 // the percent axis with them -- which is the point: a host's percentages stay
 // meaningful across a retune instead of pointing at raw travel that no longer
-// corresponds to a posture. REST_* is NOT an endpoint; it just lands wherever
-// its value falls on that axis (`get_gesture_angle` will report where).
+// corresponds to a posture. REST_* is NOT a percent-axis endpoint; it just
+// lands wherever its value falls on that axis (`get_gesture_angle` reports
+// where). Since 0.6.1 it IS the zero-degree anchor for `get_gesture_sang` and
+// the signed-degree field in `get_gesture_angles`.
 //
 // EXTEND_* need not be 0.0. It was pinned there while the axis ran from home,
 // because home IS the extension endstop as calibration defines it (the median
@@ -528,8 +530,9 @@ constexpr float FLEX_WRIST       =  0.95f;
 /// @brief Least travel, in degrees, that counts as a usable gesture range.
 ///
 /// Below this a joint is reported as having no travel rather than being driven
-/// a fraction of nothing: `get_gesture_angle` returns 255 for it and
-/// `check_limits` flags it NO_TRAVEL. Sized just above position-read noise.
+/// a fraction of nothing: `get_gesture_angle` returns 255 for it, signed-angle
+/// queries return nan, and `check_limits` flags it NO_TRAVEL. Sized just above
+/// position-read noise.
 constexpr float GESTURE_MIN_TRAVEL_DEG = 2.0f;
 
 /// @brief How much more travel the non-flip side must offer to be chosen.

--- a/src/cpp/nml_hand_exo/gesture_controller.cpp
+++ b/src/cpp/nml_hand_exo/gesture_controller.cpp
@@ -255,6 +255,7 @@ uint8_t GestureController::resolveGestureAxis(int gestureIndex,
   const int fIdx = findStateIndex(gestureLibrary[gestureIndex], "flex");
   if (fIdx == -1) return 0;
   const int eIdx = findStateIndex(gestureLibrary[gestureIndex], "extend");
+  const int rIdx = findStateIndex(gestureLibrary[gestureIndex], "rest");
   const GestureState& flex = gestureLibrary[gestureIndex].states[fIdx];
 
   uint8_t n = 0;
@@ -280,6 +281,23 @@ uint8_t GestureController::resolveGestureAxis(int gestureIndex,
       }
     }
 
+    // Signed-angle read-back is anchored at this joint's rest posture. Keep a
+    // missing rest as NAN so legacy/future gestures can still use the percent
+    // query without inventing a physical zero for the signed query.
+    float restFraction = NAN;
+    if (rIdx != -1) {
+      const GestureState& rest = gestureLibrary[gestureIndex].states[rIdx];
+      for (uint8_t r = 0; r < rest.nPairs; ++r) {
+        if (!rest.namedPairs[r].joint) continue;
+        String restName = String(rest.namedPairs[r].joint);
+        restName.toLowerCase();
+        if (restName.equals(pairName)) {
+          restFraction = rest.namedPairs[r].value;
+          break;
+        }
+      }
+    }
+
     // Match EVERY motor carrying this name: dual builds list each name twice
     // (left IDs 1-9, right IDs 11-19), same as resolveStateAngles().
     for (int i = 0; i < exo_.getMotorCount() && n < maxPoints; ++i) {
@@ -289,6 +307,7 @@ uint8_t GestureController::resolveGestureAxis(int gestureIndex,
       if (!mName.equals(pairName)) continue;
       out[n].id = id;
       out[n].extendFraction = extendFraction;
+      out[n].restFraction = restFraction;
       out[n].flexFraction = flex.namedPairs[k].value;
       ++n;
     }
@@ -369,6 +388,7 @@ uint8_t GestureController::readGestureAngles(GestureAngleRecord* out,
     }
 
     out[written].gesture = (uint8_t)g;
+    out[written].signedAngleDeg = NAN;
     if (valid == 0) {
       out[written].code = GESTURE_ANGLE_UNAVAILABLE;
     } else {
@@ -382,6 +402,28 @@ uint8_t GestureController::readGestureAngles(GestureAngleRecord* out,
         // Backlash routinely leaves a settled joint a hair beyond 0 or 100.
         out[written].code =
           (uint8_t)lroundf(constrain(mean, 0.0f, 1.0f) * 100.0f);
+      }
+
+      // OpenSim-style signed angle: use the FIRST motor named by the gesture
+      // as the physical reference, regardless of how many motors contribute
+      // to the aggregate percentage. Convert the mean percentage back onto
+      // that motor's gesture fraction, then measure physical travel from its
+      // rest state. fabs(span) removes installation/flip direction; the sign
+      // is the convention the protocol promises (toward flex positive, toward
+      // extend negative), rather than an encoder-direction artifact.
+      const GestureAxisPoint& reference = axis[0];
+      const float referenceSpan = fabsf(exo_.getGestureSpan(reference.id));
+      const float restToFlex = reference.flexFraction - reference.restFraction;
+      if (!isnan(reference.restFraction) &&
+          referenceSpan >= GESTURE_MIN_TRAVEL_DEG &&
+          fabsf(restToFlex) >= GESTURE_AXIS_MIN_SEPARATION) {
+        const float referenceFraction =
+          reference.extendFraction +
+          mean * (reference.flexFraction - reference.extendFraction);
+        const float flexDirection = restToFlex > 0.0f ? 1.0f : -1.0f;
+        out[written].signedAngleDeg =
+          (referenceFraction - reference.restFraction) *
+          flexDirection * referenceSpan;
       }
     }
     ++written;

--- a/src/cpp/nml_hand_exo/gesture_controller.h
+++ b/src/cpp/nml_hand_exo/gesture_controller.h
@@ -27,17 +27,20 @@ constexpr uint8_t GESTURE_ANGLE_ABOVE_RANGE = 102;
 /// distinguishes the two.
 constexpr uint8_t GESTURE_ANGLE_UNAVAILABLE = 255;
 
-/// @brief Where one gesture currently sits on its 0-100 percent axis.
+/// @brief Where one gesture currently sits on its percent and signed-degree axes.
 ///
-/// Packed and fixed-width so a batch is a flat array a host can consume
-/// without per-field parsing: the reply for `get_gesture_angle:all` is built
-/// from one of these per gesture, in gestureLibrary order.
-struct __attribute__((packed)) GestureAngleRecord {
-    uint8_t gesture;   ///< Index into gestureLibrary.
-    uint8_t code;      ///< 0-100 percent, or one of the codes above.
+/// The signed angle uses the first motor named by the gesture as its physical
+/// reference. Its `rest` posture is 0 degrees, motion from rest toward `flex`
+/// is positive, and motion from rest toward `extend` is negative. The value is
+/// a physical delta derived from that motor's calibrated joint-limit span;
+/// NAN means the signed angle is unavailable.
+struct GestureAngleRecord {
+    uint8_t gesture;       ///< Index into gestureLibrary.
+    uint8_t code;          ///< 0-100 percent, or one of the codes above.
+    float signedAngleDeg;  ///< Signed physical delta from rest, in degrees.
 };
 
-/// @brief One motor's two endpoints on a gesture's 0-100 percent axis.
+/// @brief One motor's endpoints and rest anchor on a gesture's percent axis.
 ///
 /// The percentage interpolates a gesture between its own `extend` and `flex`
 /// postures, so every motor it names needs BOTH of its endpoints, not a single
@@ -47,6 +50,7 @@ struct __attribute__((packed)) GestureAngleRecord {
 struct GestureAxisPoint {
     uint8_t id;             ///< Dynamixel ID.
     float extendFraction;   ///< Position at 0%, from the gesture's extend state.
+    float restFraction;     ///< Position defined by the gesture's rest state.
     float flexFraction;     ///< Position at 100%, from its flex state.
 };
 
@@ -109,8 +113,10 @@ public:
     /// 0% is the `extend` posture, NOT home. A hand parked at home therefore
     /// reads below 0 (code 101) whenever the extend constants are non-zero.
     ///
-    /// Positions come from ONE batched Dynamixel read rather than a read per
-    /// motor, so polling this per command costs a single bus transaction.
+    /// Each record also carries a signed physical angle derived from the first
+    /// motor in the gesture: rest is 0 degrees, flexion is positive, extension
+    /// is negative. Positions come from ONE batched Dynamixel read rather than
+    /// a read per motor, so polling any reply form costs one bus transaction.
     ///
     /// @param out Destination array.
     /// @param maxRecords Capacity of @p out.
@@ -121,7 +127,7 @@ public:
     uint8_t readGestureAngles(GestureAngleRecord* out, uint8_t maxRecords,
                               const String& only = String());
 
-    /// @brief Resolve one gesture's percent axis into per-motor endpoints.
+    /// @brief Resolve one gesture's percent axis and rest anchor per motor.
     ///
     /// Shared by setGestureAngle() and readGestureAngles() so the command and
     /// its read-back cannot disagree about where 0 and 100 are.

--- a/src/cpp/nml_hand_exo/nml_hand_exo.h
+++ b/src/cpp/nml_hand_exo/nml_hand_exo.h
@@ -605,7 +605,14 @@ class NMLHandExo {
     ///     together: wrist and wrist2 act on the same structure, so commanding
     ///     one alone left the other holding position against it.
     /// Adds get_gesture_angle:<gesture|all>. Gate on >= 0.6.0.
-    static constexpr const char* VERSION = "0.6.0";
+    ///
+    /// 0.6.1 -- adds rest-zeroed, OpenSim-style signed gesture angles. The
+    /// first motor named by a gesture supplies its calibrated degree scale;
+    /// motion from rest toward flex is positive and toward extend is negative.
+    /// Adds get_gesture_sang:<gesture|all> (signed degrees only) and
+    /// get_gesture_angles:<gesture|all> (percentage code plus signed degrees).
+    /// Gate on >= 0.6.1.
+    static constexpr const char* VERSION = "0.6.1";
 
   private:
     /// @brief Dynamixel2Arduino object for motor communication.

--- a/src/cpp/nml_hand_exo/utils.cpp
+++ b/src/cpp/nml_hand_exo/utils.cpp
@@ -1208,16 +1208,27 @@ void parseMessage(NMLHandExo& exo, GestureController& gc, Adafruit_BNO055& imu, 
       commandPrint("ERROR: set_gesture_angle unknown or non-addressable gesture: " + gestureStr);
     }
 
-  } else if (cmd == "get_gesture_angle") {
-    // Read-back half of set_gesture_angle, on the same axis: 0 is the gesture's
-    // extend posture and 100 is its flex posture, so a gesture commanded to 40
-    // reports 40 once it arrives.
+  } else if (cmd == "get_gesture_angle" ||
+             cmd == "get_gesture_sang" ||
+             cmd == "get_gesture_angles") {
+    // Three views of the same batched position sample:
+    //   get_gesture_angle  -> legacy 0-100 percentage/status code
+    //   get_gesture_sang  -> signed physical delta from rest, in degrees
+    //   get_gesture_angles -> both as <code>,<signed-degrees>
+    //
+    // The percentage is the read-back half of set_gesture_angle, on the same
+    // axis: 0 is the gesture's extend posture and 100 is its flex posture, so a
+    // gesture commanded to 40 reports 40 once it arrives.
     //
     // 101 and 102 mean it sits below or above those two postures -- reachable
     // by hand, by a set_angle off the axis, or simply by sitting at home, which
     // is BELOW extend whenever EXTEND_* is non-zero. 255 means no position is
     // available (no calibrated travel, or the read failed); `check_limits` says
     // which.
+    //
+    // Signed degrees use the first motor named by the gesture as the calibrated
+    // physical scale. Rest is 0, toward flex is positive, and toward extend is
+    // negative. `nan` means that physical angle is unavailable.
     //
     // Emitted with commandPrint, so on a dual-CDC build it follows the active
     // reply route: with `set_reply_route:telem` it lands on the telemetry CDC
@@ -1230,15 +1241,28 @@ void parseMessage(NMLHandExo& exo, GestureController& gc, Adafruit_BNO055& imu, 
     uint8_t count = gc.readGestureAngles(records, N_GESTURES, target);
     if (count == 0) {
       String named = target.length() ? target : String("all");
-      commandPrint("ERROR: get_gesture_angle unknown or non-addressable gesture: " + named);
+      commandPrint("ERROR: " + cmd + " unknown or non-addressable gesture: " + named);
       return;
     }
-    String out = "GESTURE_ANGLE:";
+    const bool signedOnly = cmd == "get_gesture_sang";
+    const bool combined = cmd == "get_gesture_angles";
+    String out = signedOnly ? "GESTURE_SANG:" :
+                 (combined ? "GESTURE_ANGLES:" : "GESTURE_ANGLE:");
     for (uint8_t i = 0; i < count; ++i) {
       out += " ";
       out += gestureLibrary[records[i].gesture].name;
       out += "=";
-      out += String(records[i].code);
+      if (!signedOnly) {
+        out += String(records[i].code);
+        if (combined) out += ",";
+      }
+      if (signedOnly || combined) {
+        if (isnan(records[i].signedAngleDeg)) {
+          out += "nan";
+        } else {
+          out += String(records[i].signedAngleDeg, 2);
+        }
+      }
     }
     commandPrint(out);
 
@@ -1384,6 +1408,8 @@ void parseMessage(NMLHandExo& exo, GestureController& gc, Adafruit_BNO055& imu, 
     commandPrint(F(" set_gesture_state     |  NAME:VALUE          | // Set exo gesture state"));
     commandPrint(F(" set_gesture_angle     |  NAME:0-100          | // Interpolate a gesture: 0=its extend state, 100=its flex state"));
     commandPrint(F(" get_gesture_angle     |  NAME/ALL            | // Read positions as 0-100 (101/102 out of range, 255 no travel)"));
+    commandPrint(F(" get_gesture_sang      |  NAME/ALL            | // Read signed degrees from rest: flex positive, extend negative"));
+    commandPrint(F(" get_gesture_angles    |  NAME/ALL            | // Read <percent-code>,<signed-degrees> pairs"));
     commandPrint(F(" get_gesture_state     |                      | // Get exo gesture state"));
     commandPrint(F(" cycle_gesture         |                      | // Executes the next gesture in the library"));
     commandPrint(F(" cycle_gesture_state   |                      | // Cycles the next gesture state"));

--- a/src/nml_hand_exo/interface/_hand_exo.py
+++ b/src/nml_hand_exo/interface/_hand_exo.py
@@ -37,8 +37,12 @@ FW_CURRENT_BUDGET = (0, 4, 0)
 #: still ACKed -- so there is no reply to detect it from, only the version.
 FW_GESTURE_ANGLE_READBACK = (0, 6, 0)
 
-#: Reported instead of a percentage when a joint sits outside its calibrated
-#: travel: below the 0% end (home) or above the 100% end (flexion endstop).
+#: Firmware version that added rest-zeroed signed gesture angles and the
+#: combined percentage/signed-degree query.
+FW_GESTURE_SIGNED_ANGLE = (0, 6, 1)
+
+#: Reported instead of a percentage when a joint sits outside its gesture
+#: endpoints: below the 0% extend posture or above the 100% flex posture.
 #: Reachable by moving the hand by hand, or by a ``set_angle`` off the axis.
 GESTURE_ANGLE_BELOW_RANGE = 101
 GESTURE_ANGLE_ABOVE_RANGE = 102
@@ -92,6 +96,10 @@ def parse_firmware_version(text: str) -> tuple[int, ...]:
 #: Prefix of the firmware's ``get_gesture_angle`` reply.
 GESTURE_ANGLE_PREFIX = "GESTURE_ANGLE:"
 
+#: Prefixes of the firmware's signed-only and combined gesture-angle replies.
+GESTURE_SANG_PREFIX = "GESTURE_SANG:"
+GESTURE_ANGLES_PREFIX = "GESTURE_ANGLES:"
+
 
 def parse_gesture_angles(text: str) -> dict[str, int]:
     """Parse a ``GESTURE_ANGLE:`` reply into ``{gesture: code}``.
@@ -130,6 +138,100 @@ def parse_gesture_angles(text: str) -> dict[str, int]:
                 angles[name] = int(value)
             except ValueError:
                 continue
+        return angles
+    return {}
+
+
+def parse_gesture_signed_angles(text: str) -> dict[str, float | None]:
+    """Parse a ``GESTURE_SANG:`` reply into signed degree deltas.
+
+    ``rest`` is 0 degrees by convention, motion toward ``flex`` is positive,
+    and motion toward ``extend`` is negative. ``nan`` is returned as ``None``
+    so callers do not need floating-point special-value checks.
+
+    Args:
+        text (str): Raw reply text, possibly multi-line.
+
+    Returns:
+        dict[str, float | None]: Gesture name -> signed angle in degrees, or
+        ``None`` when the firmware could not produce a physical angle.
+
+    """
+    if not text:
+        return {}
+    for line in str(text).splitlines():
+        line = line.strip()
+        if not line.startswith(GESTURE_SANG_PREFIX):
+            continue
+        body = line[len(GESTURE_SANG_PREFIX):].strip().rstrip(";")
+        angles: dict[str, float | None] = {}
+        for token in body.split():
+            name, sep, value = token.partition("=")
+            name = name.strip().lower()
+            if not sep or not name:
+                continue
+            if value.strip().lower() == "nan":
+                angles[name] = None
+                continue
+            try:
+                angle = float(value)
+            except ValueError:
+                continue
+            if math.isfinite(angle):
+                angles[name] = angle
+        return angles
+    return {}
+
+
+def parse_gesture_angle_pairs(
+    text: str,
+) -> dict[str, dict[str, int | float | None]]:
+    """Parse a combined ``GESTURE_ANGLES:`` reply.
+
+    Each wire token is ``name=<percentage-code>,<signed-degrees>``. The first
+    field keeps the exact ``get_gesture_angle`` encoding, including status
+    codes 101, 102, and 255; the second uses the rest-zeroed signed convention.
+
+    Args:
+        text (str): Raw reply text, possibly multi-line.
+
+    Returns:
+        dict: Gesture names mapped to ``fraction`` and ``angle_delta_deg``.
+        An unavailable signed angle is represented by ``None``.
+
+    """
+    if not text:
+        return {}
+    for line in str(text).splitlines():
+        line = line.strip()
+        if not line.startswith(GESTURE_ANGLES_PREFIX):
+            continue
+        body = line[len(GESTURE_ANGLES_PREFIX):].strip().rstrip(";")
+        angles: dict[str, dict[str, int | float | None]] = {}
+        for token in body.split():
+            name, sep, value = token.partition("=")
+            fraction_text, comma, signed_text = value.partition(",")
+            name = name.strip().lower()
+            if not sep or not comma or not name:
+                continue
+            try:
+                fraction = int(fraction_text)
+            except ValueError:
+                continue
+            signed_angle: float | None
+            if signed_text.strip().lower() == "nan":
+                signed_angle = None
+            else:
+                try:
+                    signed_angle = float(signed_text)
+                except ValueError:
+                    continue
+                if not math.isfinite(signed_angle):
+                    continue
+            angles[name] = {
+                "fraction": fraction,
+                "angle_delta_deg": signed_angle,
+            }
         return angles
     return {}
 
@@ -1513,6 +1615,69 @@ class HandExo(object):
             self._require_gesture_firmware(name)
         self.send_command(f"get_gesture_angle:{name}")
         return parse_gesture_angles(
+            self._receive(wait_until_return=True, timeout=timeout)
+        )
+
+    def get_gesture_sang(
+        self, gesture: str = "all", timeout: float = 1.0
+    ) -> dict[str, float | None]:
+        """Read OpenSim-style signed gesture angles in degrees.
+
+        The first motor named by each gesture supplies the calibrated physical
+        degree scale. Its ``rest`` state is 0 degrees; positions toward
+        ``flex`` are positive and positions toward ``extend`` are negative.
+        Multi-motor gesture percentages are still aggregated as documented by
+        :meth:`get_gesture_angle`, then mapped to that first-motor scale.
+
+        Args:
+            gesture (str): A single angle-addressable gesture, or ``"all"``.
+            timeout (float): Seconds to wait for the reply.
+
+        Returns:
+            dict[str, float | None]: Gesture name -> signed degree delta from
+            rest. ``None`` means no signed angle was available.
+
+        Raises:
+            RuntimeError: If the device firmware is older than 0.6.1.
+
+        """
+        self._require_firmware(FW_GESTURE_SIGNED_ANGLE, "get_gesture_sang")
+        name = str(gesture).strip().lower() or "all"
+        if name != "all":
+            self._require_gesture_firmware(name)
+        self.send_command(f"get_gesture_sang:{name}")
+        return parse_gesture_signed_angles(
+            self._receive(wait_until_return=True, timeout=timeout)
+        )
+
+    def get_gesture_angles(
+        self, gesture: str = "all", timeout: float = 1.0
+    ) -> dict[str, dict[str, int | float | None]]:
+        """Read percentage codes and signed degree deltas together.
+
+        This is the combined form of :meth:`get_gesture_angle` and
+        :meth:`get_gesture_sang`, produced from one batched motor read. Each
+        result has ``fraction`` (the legacy 0-100/status code) and
+        ``angle_delta_deg`` (rest-zeroed signed degrees, or ``None``).
+
+        Args:
+            gesture (str): A single angle-addressable gesture, or ``"all"``.
+            timeout (float): Seconds to wait for the reply.
+
+        Returns:
+            dict: Gesture names mapped to ``fraction`` and
+            ``angle_delta_deg`` fields.
+
+        Raises:
+            RuntimeError: If the device firmware is older than 0.6.1.
+
+        """
+        self._require_firmware(FW_GESTURE_SIGNED_ANGLE, "get_gesture_angles")
+        name = str(gesture).strip().lower() or "all"
+        if name != "all":
+            self._require_gesture_firmware(name)
+        self.send_command(f"get_gesture_angles:{name}")
+        return parse_gesture_angle_pairs(
             self._receive(wait_until_return=True, timeout=timeout)
         )
 


### PR DESCRIPTION
## Summary

Bump the OpenRB firmware revision to 0.6.1 and add OpenSim-style signed gesture-angle readback alongside the existing percentage/status representation.

This change adds two commands:

- `get_gesture_sang:<gesture|all>` returns signed physical degree deltas from the gesture's rest posture.
- `get_gesture_angles:<gesture|all>` returns both the existing percentage/status code and the signed degree delta from one batched Dynamixel read.

The existing `get_gesture_angle:<gesture|all>` response remains unchanged.

## Signed-angle convention

For each gesture, the first motor named by that gesture supplies the calibrated physical degree scale:

- `rest` is exactly 0 degrees.
- Motion from rest toward `flex` is positive.
- Motion from rest toward `extend` is negative.
- Encoder direction and the motor `flip` flag do not change this public sign convention.
- `nan` reports that a signed physical angle is unavailable.

The percentage continues to be the mean of all usable motors in a multi-motor gesture. The degree value maps that aggregate position onto the first motor's calibrated span. Therefore `thumb` uses `thumbadd`, `wrist` uses `wrist`, and dual firmware uses the left-side instance because IDs 1-9 precede IDs 11-19.

## Protocol and host API

Added firmware replies:

- `GESTURE_SANG: index=-12.50 middle=0.00 wrist=34.75`
- `GESTURE_ANGLES: index=0,-12.50 middle=45,0.00 wrist=255,nan`

Added matching Python support:

- `HandExo.get_gesture_sang()`
- `HandExo.get_gesture_angles()`
- tolerant signed-only and combined reply parsers
- a 0.6.1 firmware feature gate

Combined Python results expose `fraction` and `angle_delta_deg` fields. The fraction field preserves codes 101/102/255, while an unavailable signed angle is represented as `None`.

## UDP pose acknowledgements

Updated `examples/08_udp` to query `get_gesture_angles:all` after each dispatched command.

The binary pose frame is versioned from `NGA1` to `NGA2` because each joint record widens from one byte to:

- `uint8 fraction_code`
- `float32 angle_delta_deg`

The frame remains little-endian and additive: the existing ASCII integer command ack is still sent first and is unchanged. Missing/unavailable joints use fraction code 255 and IEEE NaN for the signed angle. The receiver probes support at startup and disables pose frames without stalling command acks when connected to firmware older than 0.6.1.

The Tk UDP panel now renders both percentage/status and signed degrees.

## Documentation

Updated the serial protocol, dual-exo architecture, known gotchas, firmware constants, API docstrings, and UDP example guidance with:

- command and response schemas
- the rest-zeroed sign convention
- out-of-range and unavailable behavior
- first-motor scaling for multi-motor gestures
- the dual-build left-reference caveat
- the `NGA2` binary record layout and compatibility behavior

## Validation

- `python -m pytest examples/tests -q` — 98 passed
- `python -m pytest tests -q` — 11 passed
- OpenRB-150 firmware compile succeeded:
  - flash: 141,628 / 262,144 bytes (54%)
  - global RAM: 22,884 / 32,768 bytes (69%)
- `git diff --check` passed

## Hardware follow-up

Flashed firmware 0.6.1 and confirmed on the calibrated RH exo that:

1. `version` reports 0.6.1.
2. `get_gesture_sang:<gesture>` reports extend as negative, rest near zero, and flex as positive.
3. `get_gesture_angles:<gesture>` reports the matching percentage/status and signed degree pair.
4. `get_gesture_angles:all` produces a valid `NGA2` pose acknowledgement in the UDP example.